### PR TITLE
Refactor internal state to ensure consistent request id in logging

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: required
 language: go
 
 go:
-  - 1.9
+  - "1.11"
 
 services:
   - docker

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -86,6 +86,14 @@
   revision = "3a771d992973f24aa725d07868b467d1ddfceafb"
 
 [[projects]]
+  digest = "1:166438587ed45ac211dab8a3ecebf4fa0c186d0db63430fb9127bbc2e5fcdc67"
+  name = "github.com/cenkalti/backoff"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "1e4cf3da559842a91afcb6ea6141451e6c30c618"
+  version = "v2.1.1"
+
+[[projects]]
   branch = "master"
   digest = "1:e48c63e818c67fbf3d7afe20bba33134ab1a5bf384847385384fd027652a5a96"
   name = "github.com/containerd/continuity"
@@ -397,6 +405,7 @@
     "github.com/aws/aws-sdk-go-v2/aws/external",
     "github.com/aws/aws-sdk-go-v2/service/iam",
     "github.com/aws/aws-sdk-go-v2/service/sts",
+    "github.com/cenkalti/backoff",
     "github.com/davecgh/go-spew/spew",
     "github.com/fsouza/go-dockerclient",
     "github.com/gorilla/mux",

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -344,6 +344,14 @@
   revision = "1dc9a6cbc91aacc3e8b2d63db4d2e957a5394ac4"
 
 [[projects]]
+  digest = "1:274f67cb6fed9588ea2521ecdac05a6d62a8c51c074c1fccc6a49a40ba80e925"
+  name = "github.com/satori/go.uuid"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "f58768cc1a7a7e77a3bd49e98cdd21419399b6a3"
+  version = "v1.2.0"
+
+[[projects]]
   branch = "master"
   digest = "1:58f7b701c6c24c34e4800ea8148258e8967b934a4c05da1fb34c5dffb1e34f81"
   name = "github.com/seatgeek/logrus-gelf-formatter"
@@ -396,6 +404,7 @@
     "github.com/patrickmn/go-cache",
     "github.com/prometheus/client_golang/prometheus",
     "github.com/prometheus/client_golang/prometheus/promhttp",
+    "github.com/satori/go.uuid",
     "github.com/seatgeek/logrus-gelf-formatter",
     "github.com/sirupsen/logrus",
   ]

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -65,3 +65,7 @@ required = ["github.com/davecgh/go-spew/spew"]
 [[override]]
   name = "github.com/docker/libnetwork"
   revision = "1f28166bb386cf9223d2d00a28382b0e474be314"
+
+[[constraint]]
+  name = "github.com/cenkalti/backoff"
+  version = "2.1.1"

--- a/internal/aws.go
+++ b/internal/aws.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/armon/go-metrics"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/aws/external"
 	"github.com/aws/aws-sdk-go-v2/service/iam"
@@ -37,22 +36,20 @@ func ConfigureAWS() {
 	stsService = sts.New(cfg)
 }
 
-func readRoleFromAWS(role string, labels []metrics.Label) (*iam.Role, []metrics.Label, error) {
-	logWithLabels(labels).Infof("Looking for IAM role for %s", role)
+func readRoleFromAWS(role string, request *Request) (*iam.Role, error) {
+	request.log.Infof("Looking for IAM role for %s", role)
 
 	roleObject := &iam.Role{}
-
 	if roleObject, ok := roleCache.Get(role); ok {
-		labels = append(labels, metrics.Label{Name: "read_role_from_aws_cache", Value: "hit"})
-
-		logWithLabels(labels).Infof("Found IAM role %s in cache", role)
-		return roleObject.(*iam.Role), labels, nil
+		request.setLabel("read_role_from_aws_cache", "hit")
+		request.log.Infof("Found IAM role %s in cache", role)
+		return roleObject.(*iam.Role), nil
 	}
 
-	labels = append(labels, metrics.Label{Name: "read_role_from_aws_cache", Value: "miss"})
+	request.setLabel("read_role_from_aws_cache", "miss")
 
 	if strings.Contains(role, "@") { // IAM_ROLE=my-role@012345678910
-		logWithLabels(labels).Infof("Constructing IAM role info for %s manually", role)
+		request.log.Infof("Constructing IAM role info for %s manually", role)
 		chunks := strings.SplitN(role, "@", 2)
 		nameChunks := strings.Split(chunks[0], "/")
 
@@ -61,7 +58,7 @@ func readRoleFromAWS(role string, labels []metrics.Label) (*iam.Role, []metrics.
 			RoleName: aws.String(nameChunks[len(nameChunks)-1]),
 		}
 	} else if strings.HasPrefix(role, "arn:aws:iam") { // IAM_ROLE=arn:aws:iam::012345678910:role/my-role
-		logWithLabels(labels).Infof("Using IAM role ARN as is for %s", role)
+		request.log.Infof("Using IAM role ARN as is for %s", role)
 
 		chunks := strings.SplitN(role, ":role/", 2)
 		nameChunks := strings.Split(chunks[1], "/")
@@ -71,35 +68,34 @@ func readRoleFromAWS(role string, labels []metrics.Label) (*iam.Role, []metrics.
 			RoleName: aws.String(nameChunks[len(nameChunks)-1]),
 		}
 	} else { // IAM_ROLE=my-role
-		logWithLabels(labels).Infof("Requesting IAM role info for %s from AWS", role)
+		request.log.Infof("Requesting IAM role info for %s from AWS", role)
 		req := iamService.GetRoleRequest(&iam.GetRoleInput{
 			RoleName: aws.String(role),
 		})
 
 		resp, err := req.Send()
 		if err != nil {
-			return nil, labels, err
+			return nil, err
 		}
 
 		roleObject = resp.Role
 	}
 
 	roleCache.Set(role, roleObject, cache.DefaultExpiration)
-	return roleObject, labels, nil
+	return roleObject, nil
 }
 
-func assumeRoleFromAWS(arn string, labels []metrics.Label) (*sts.AssumeRoleOutput, []metrics.Label, error) {
-	logWithLabels(labels).Infof("Looking for STS Assume Role for %s", arn)
+func assumeRoleFromAWS(arn string, request *Request) (*sts.AssumeRoleOutput, error) {
+	request.log.Infof("Looking for STS Assume Role for %s", arn)
 
 	if assumedRole, ok := permissionCache.Get(arn); ok {
-		labels = append(labels, metrics.Label{Name: "assume_role_from_aws_cache", Value: "hit"})
-
-		logWithLabels(labels).Infof("Found STS Assume Role %s in cache", arn)
-		return assumedRole.(*sts.AssumeRoleOutput), labels, nil
+		request.setLabel("assume_role_from_aws_cache", "hit")
+		request.log.Infof("Found STS Assume Role %s in cache", arn)
+		return assumedRole.(*sts.AssumeRoleOutput), nil
 	}
-	labels = append(labels, metrics.Label{Name: "assume_role_from_aws_cache", Value: "miss"})
 
-	logWithLabels(labels).Infof("Requesting STS Assume Role info for %s from AWS", arn)
+	request.setLabel("assume_role_from_aws_cache", "miss")
+	request.log.Infof("Requesting STS Assume Role info for %s from AWS", arn)
 	req := stsService.AssumeRoleRequest(&sts.AssumeRoleInput{
 		RoleArn:         aws.String(arn),
 		RoleSessionName: aws.String("go-metadataproxy"),
@@ -107,14 +103,11 @@ func assumeRoleFromAWS(arn string, labels []metrics.Label) (*sts.AssumeRoleOutpu
 
 	assumedRole, err := req.Send()
 	if err != nil {
-		return nil, labels, err
+		return nil, err
 	}
 
 	ttl := assumedRole.Credentials.Expiration.Sub(time.Now()) - 1*time.Minute
-
-	logWithLabels(labels).Infof("Will cache STS Assumed Role info for %s in %s", arn, ttl.String())
-
+	request.log.Infof("Will cache STS Assumed Role info for %s in %s", arn, ttl.String())
 	permissionCache.Set(arn, assumedRole, ttl)
-
-	return assumedRole, labels, nil
+	return assumedRole, nil
 }

--- a/internal/docker.go
+++ b/internal/docker.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"strings"
 
-	metrics "github.com/armon/go-metrics"
 	"github.com/fsouza/go-dockerclient"
 	log "github.com/sirupsen/logrus"
 )
@@ -35,24 +34,25 @@ func ConfigureDocker() {
 	dockerClient = client
 }
 
-func findDockerContainer(ip string, labels []metrics.Label) (*docker.Container, []metrics.Label, error) {
+func findDockerContainer(ip string, request *Request) (*docker.Container, error) {
 	var container *docker.Container
 
-	logWithLabels(labels).Infof("Looking up container info for %s in docker", ip)
+	request.log.Infof("Looking up container info for %s in docker", ip)
 	containers, err := dockerClient.ListContainers(docker.ListContainersOptions{All: true})
 	if err != nil {
-		return nil, labels, err
+		return nil, err
 	}
 
-	container, err = findContainerByIP(ip, labels, containers)
+	container, err = findContainerByIP(ip, request, containers)
 	if err != nil {
-		return nil, labels, err
+		return nil, err
 	}
 
+	additionalLabels := make(map[string]string)
 	if len(copyDockerLabels) > 0 {
 		for _, label := range copyDockerLabels {
 			if v, ok := container.Config.Labels[label]; ok {
-				labels = append(labels, metrics.Label{Name: labelName("container", label), Value: v})
+				additionalLabels[labelName("container", label)] = v
 			}
 		}
 	}
@@ -60,19 +60,23 @@ func findDockerContainer(ip string, labels []metrics.Label) (*docker.Container, 
 	if len(copyDockerEnvs) > 0 {
 		for _, label := range copyDockerEnvs {
 			if v, ok := findDockerContainerEnvValue(container, label); ok {
-				labels = append(labels, metrics.Label{Name: labelName("container", label), Value: v})
+				additionalLabels[labelName("container", label)] = v
 			}
 		}
 	}
 
-	return container, labels, nil
+	if len(additionalLabels) > 0 {
+		request.setLabels(additionalLabels)
+	}
+
+	return container, nil
 }
 
-func findContainerByIP(ip string, labels []metrics.Label, containers []docker.APIContainers) (*docker.Container, error) {
+func findContainerByIP(ip string, request *Request, containers []docker.APIContainers) (*docker.Container, error) {
 	for _, container := range containers {
 		for name, network := range container.Networks.Networks {
 			if network.IPAddress == ip {
-				logWithLabels(labels).Infof("Found container IP '%s' in %+v within network '%s'", ip, container.Names, name)
+				request.log.Infof("Found container IP '%s' in %+v within network '%s'", ip, container.Names, name)
 
 				inspectedContainer, err := dockerClient.InspectContainer(container.ID)
 				if err != nil {
@@ -87,13 +91,13 @@ func findContainerByIP(ip string, labels []metrics.Label, containers []docker.AP
 	return nil, fmt.Errorf("Could not find any container with IP %s", ip)
 }
 
-func findDockerContainerIAMRole(container *docker.Container) (string, error) {
+func findDockerContainerIAMRole(container *docker.Container, request *Request) (string, error) {
 	if v, ok := findDockerContainerEnvValue(container, "IAM_ROLE"); ok {
 		return v, nil
 	}
 
 	if defaultRole != "" {
-		log.Infof("Could not find IAM_ROLE in the container, returning DEFAULT_ROLE %s", defaultRole)
+		request.log.Infof("Could not find IAM_ROLE in the container, returning DEFAULT_ROLE %s", defaultRole)
 		return defaultRole, nil
 	}
 

--- a/internal/docker.go
+++ b/internal/docker.go
@@ -10,10 +10,11 @@ import (
 )
 
 var (
-	dockerClient     *docker.Client
-	defaultRole      = os.Getenv("DEFAULT_ROLE")
-	copyDockerLabels = strings.Split(os.Getenv("COPY_DOCKER_LABELS"), ",")
-	copyDockerEnvs   = strings.Split(os.Getenv("COPY_DOCKER_ENV"), ",")
+	dockerClient       *docker.Client
+	defaultRole        = os.Getenv("DEFAULT_ROLE")
+	copyDockerLabels   = strings.Split(os.Getenv("COPY_DOCKER_LABELS"), ",")
+	copyDockerEnvs     = strings.Split(os.Getenv("COPY_DOCKER_ENV"), ",")
+	copyRequestHeaders = strings.Split(os.Getenv("COPY_REQUEST_HEADERS"), ",")
 )
 
 // ConfigureDocker will setup a docker client used during normal operations

--- a/internal/http_handler.go
+++ b/internal/http_handler.go
@@ -327,7 +327,6 @@ func passthroughHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	defer resp.Body.Close()
 
-	w.Header().Set("X-Powered-By", "go-metadataproxy")
 	w.WriteHeader(resp.StatusCode)
 	io.Copy(w, resp.Body)
 
@@ -338,6 +337,7 @@ func passthroughHandler(w http.ResponseWriter, r *http.Request) {
 // handles: /metrics
 func metricsHandler(w http.ResponseWriter, r *http.Request) {
 	request := NewRequest()
+
 	request.setLabels(map[string]string{
 		"handler_name": "metrics",
 		"remote_addr":  remoteIP(r.RemoteAddr),

--- a/internal/http_handler.go
+++ b/internal/http_handler.go
@@ -82,10 +82,10 @@ func StarServer() {
 // handles: /{api_version}/meta-data/iam/info
 // handles: /{api_version}/meta-data/iam/info/{junk}
 func iamInfoHandler(w http.ResponseWriter, r *http.Request) {
-	request := NewRequest()
-
-	// setup basic telemetry
 	vars := mux.Vars(r)
+
+	request := NewRequest()
+	request.setLabelsFromRequestHeader(r)
 	request.setLabels(map[string]string{
 		"aws_api_version": vars["api_version"],
 		"handler_name":    "iam-info-handler",
@@ -153,6 +153,7 @@ func iamSecurityCredentialsName(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 
 	request := NewRequest()
+	request.setLabelsFromRequestHeader(r)
 	request.setLabels(map[string]string{
 		"aws_api_version": vars["api_version"],
 		"handler_name":    "iam-security-credentials-name",
@@ -198,6 +199,7 @@ func iamSecurityCredentialsForRole(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 
 	request := NewRequest()
+	request.setLabelsFromRequestHeader(r)
 	request.setLabels(map[string]string{
 		"aws_api_version": vars["api_version"],
 		"handler_name":    "iam-security-crentials-for-role",
@@ -276,10 +278,10 @@ func iamSecurityCredentialsForRole(w http.ResponseWriter, r *http.Request) {
 
 // handles: /*
 func passthroughHandler(w http.ResponseWriter, r *http.Request) {
-	// setup basic telemetry
 	vars := mux.Vars(r)
 
 	request := NewRequest()
+	request.setLabelsFromRequestHeader(r)
 	request.setLabels(map[string]string{
 		"aws_api_version": vars["api_version"],
 		"handler_name":    "passthrough",
@@ -337,7 +339,7 @@ func passthroughHandler(w http.ResponseWriter, r *http.Request) {
 // handles: /metrics
 func metricsHandler(w http.ResponseWriter, r *http.Request) {
 	request := NewRequest()
-
+	request.setLabelsFromRequestHeader(r)
 	request.setLabels(map[string]string{
 		"handler_name": "metrics",
 		"remote_addr":  remoteIP(r.RemoteAddr),

--- a/internal/http_helper.go
+++ b/internal/http_helper.go
@@ -26,6 +26,7 @@ func findContainerRoleByAddress(addr string, request *Request) (*iam.Role, error
 
 	b := backoff.NewExponentialBackOff()
 	b.MaxElapsedTime = 5 * time.Second
+	b.InitialInterval = 5 * time.Millisecond
 
 	retryable := func() error {
 		var err error

--- a/internal/logging.go
+++ b/internal/logging.go
@@ -3,7 +3,6 @@ package internal
 import (
 	"os"
 
-	"github.com/armon/go-metrics"
 	gelf "github.com/seatgeek/logrus-gelf-formatter"
 	log "github.com/sirupsen/logrus"
 )
@@ -30,14 +29,4 @@ func ConfigureLogging() {
 			log.Fatal("Unknown log_format (text, json or gelf)")
 		}
 	}
-}
-
-func logWithLabels(labels []metrics.Label) *log.Entry {
-	fields := log.Fields{}
-
-	for _, label := range labels {
-		fields[label.Name] = label.Value
-	}
-
-	return log.WithFields(fields)
 }

--- a/internal/request.go
+++ b/internal/request.go
@@ -1,0 +1,57 @@
+package internal
+
+import (
+	"net/http"
+
+	metrics "github.com/armon/go-metrics"
+	"github.com/satori/go.uuid"
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	telemetryPrefix = "metadataproxy"
+)
+
+type Request struct {
+	id            string
+	log           *logrus.Entry
+	metricsLabels []metrics.Label
+	loggingLabels logrus.Fields
+}
+
+func NewRequest() *Request {
+	id := uuid.NewV4()
+
+	return &Request{
+		id:  id.String(),
+		log: logrus.WithField("request_id", id.String()),
+	}
+}
+
+func (r *Request) setLabel(key, value string) {
+	r.setLabels(map[string]string{key: value})
+}
+
+func (r *Request) setLabels(pairs map[string]string) {
+	for key, value := range pairs {
+		r.metricsLabels = append(r.metricsLabels, metrics.Label{Name: key, Value: value})
+		r.loggingLabels[key] = value
+	}
+
+	r.log = r.log.WithFields(r.loggingLabels)
+}
+
+func (r *Request) incrCounterWithLabels(path []string, val float32) {
+	path = append([]string{telemetryPrefix}, path...)
+	metrics.IncrCounterWithLabels(path, val, r.metricsLabels)
+}
+
+func (r *Request) setGaugeWithLabels(path []string, val float32) {
+	path = append([]string{telemetryPrefix}, path...)
+	metrics.SetGaugeWithLabels(path, val, r.metricsLabels)
+}
+
+func (r *Request) setResponseHeaders(w http.ResponseWriter) {
+	w.Header().Set("X-Powered-By", "go-metadataproxy")
+	w.Header().Set("X-Request-ID", r.id)
+}

--- a/internal/request.go
+++ b/internal/request.go
@@ -55,3 +55,16 @@ func (r *Request) setResponseHeaders(w http.ResponseWriter) {
 	w.Header().Set("X-Powered-By", "go-metadataproxy")
 	w.Header().Set("X-Request-ID", r.id)
 }
+
+func (r *Request) setLabelsFromRequestHeader(httpRequest *http.Request) {
+	if len(copyRequestHeaders) == 0 {
+		return
+	}
+
+	labels := make(map[string]string)
+	for _, label := range copyRequestHeaders {
+		if v := httpRequest.Header.Get("label"); v != "" {
+			labels[labelName("header", label)] = v
+		}
+	}
+}


### PR DESCRIPTION
### Rationale

Today it's pretty hard to debug everything that was being logged for a specific HTTP request since there is no stable value you can query on from the first HTTP request until the end.

This PR introduces a `request_id` which will be stable for the duration of the request, and due to its UUIDv4 value, will be globally unique (or close to it) for the lifetime of the service.

The request ID will always be returned in a proxied response (`X-Request-ID`), which should make it much easier to correlate request and actions done.

The value will also be logged as `request_id` in any logs from the request.

The value will *not* be emitted via telemetry as the cardinality of the field would be mostly useless

Signed-off-by: Christian Winther <jippignu@gmail.com>