### PR TITLE
Add support for IAM external ID

### DIFF
--- a/internal/aws.go
+++ b/internal/aws.go
@@ -85,18 +85,18 @@ func readRoleFromAWS(role string, request *Request) (*iam.Role, error) {
 	return roleObject, nil
 }
 
-func constructAssumeRoleInput(arn string, externalId string, sessionName string) (*sts.AssumeRoleInput) {
+func constructAssumeRoleInput(arn string, externalId string) (*sts.AssumeRoleInput) {
 	if externalId == "" {
 		return &sts.AssumeRoleInput{
 			RoleArn:         aws.String(arn),
-			RoleSessionName: aws.String(sessionName),
+			RoleSessionName: aws.String("go-metadataproxy"),
 		}
 	}
 
 	return &sts.AssumeRoleInput{
 		ExternalId:      aws.String(externalId),
 		RoleArn:         aws.String(arn),
-		RoleSessionName: aws.String(sessionName),
+		RoleSessionName: aws.String("go-metadataproxy"),
 	}
 }
 
@@ -111,7 +111,7 @@ func assumeRoleFromAWS(arn string, externalId string, request *Request) (*sts.As
 
 	request.setLabel("assume_role_from_aws_cache", "miss")
 	request.log.Infof("Requesting STS Assume Role info for %s from AWS", arn)
-	req := stsService.AssumeRoleRequest(constructAssumeRoleInput(arn, externalId, "go-metadataproxy"))
+	req := stsService.AssumeRoleRequest(constructAssumeRoleInput(arn, externalId))
 
 	assumedRole, err := req.Send()
 	if err != nil {

--- a/internal/aws.go
+++ b/internal/aws.go
@@ -86,7 +86,6 @@ func readRoleFromAWS(role string, request *Request) (*iam.Role, error) {
 }
 
 func constructAssumeRoleInput(arn string, externalId string, sessionName string) (*sts.AssumeRoleInput) {
-
 	if externalId == "" {
 		return &sts.AssumeRoleInput{
 			RoleArn:         aws.String(arn),
@@ -99,7 +98,6 @@ func constructAssumeRoleInput(arn string, externalId string, sessionName string)
 		RoleArn:         aws.String(arn),
 		RoleSessionName: aws.String(sessionName),
 	}
-
 }
 
 func assumeRoleFromAWS(arn string, externalId string, request *Request) (*sts.AssumeRoleOutput, error) {

--- a/internal/docker.go
+++ b/internal/docker.go
@@ -105,6 +105,14 @@ func findDockerContainerIAMRole(container *docker.Container, request *Request) (
 	return "", fmt.Errorf("Could not find IAM_ROLE in the container ENV config")
 }
 
+func findDockerContainerExternalId(container *docker.Container, request *Request) (string, error) {
+	if v, ok := findDockerContainerEnvValue(container, "IAM_EXTERNAL_ID"); ok {
+		return v, nil
+	}
+
+	return "", nil
+}
+
 func findDockerContainerEnvValue(container *docker.Container, key string) (string, bool) {
 	for _, envPair := range container.Config.Env {
 		chunks := strings.SplitN(envPair, "=", 2)

--- a/internal/docker.go
+++ b/internal/docker.go
@@ -105,9 +105,9 @@ func findDockerContainerIAMRole(container *docker.Container, request *Request) (
 	return "", fmt.Errorf("Could not find IAM_ROLE in the container ENV config")
 }
 
-func findDockerContainerExternalId(container *docker.Container, request *Request) (string, error) {
+func findDockerContainerExternalId(container *docker.Container, request *Request) string {
 	v, _ := findDockerContainerEnvValue(container, "IAM_EXTERNAL_ID")
-	return v, nil
+	return v
 }
 
 func findDockerContainerEnvValue(container *docker.Container, key string) (string, bool) {

--- a/internal/docker.go
+++ b/internal/docker.go
@@ -106,11 +106,8 @@ func findDockerContainerIAMRole(container *docker.Container, request *Request) (
 }
 
 func findDockerContainerExternalId(container *docker.Container, request *Request) (string, error) {
-	if v, ok := findDockerContainerEnvValue(container, "IAM_EXTERNAL_ID"); ok {
-		return v, nil
-	}
-
-	return "", nil
+	v, _ := findDockerContainerEnvValue(container, "IAM_EXTERNAL_ID")
+	return v, nil
 }
 
 func findDockerContainerEnvValue(container *docker.Container, key string) (string, bool) {

--- a/internal/http_handler.go
+++ b/internal/http_handler.go
@@ -173,7 +173,7 @@ func iamSecurityCredentialsName(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// read the role from AWS
-	roleInfo, externalId, err := findContainerRoleByAddress(r.RemoteAddr, request)
+	roleInfo, _, err := findContainerRoleByAddress(r.RemoteAddr, request)
 	if err != nil {
 		request.setLabels(map[string]string{
 			"response_code":     "404",

--- a/internal/http_handler.go
+++ b/internal/http_handler.go
@@ -105,7 +105,7 @@ func iamInfoHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// read the role from AWS
-	roleInfo, err := findContainerRoleByAddress(r.RemoteAddr, request)
+	roleInfo, externalId, err := findContainerRoleByAddress(r.RemoteAddr, request)
 	if err != nil {
 		request.setLabels(map[string]string{
 			"response_code":     "404",
@@ -121,7 +121,7 @@ func iamInfoHandler(w http.ResponseWriter, r *http.Request) {
 	request.setLabel("role_name", *roleInfo.RoleName)
 
 	// assume the role
-	assumeRole, err := assumeRoleFromAWS(*roleInfo.Arn, request)
+	assumeRole, err := assumeRoleFromAWS(*roleInfo.Arn, externalId, request)
 	if err != nil {
 		request.setLabels(map[string]string{
 			"response_code":     "404",
@@ -173,7 +173,7 @@ func iamSecurityCredentialsName(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// read the role from AWS
-	roleInfo, err := findContainerRoleByAddress(r.RemoteAddr, request)
+	roleInfo, externalId, err := findContainerRoleByAddress(r.RemoteAddr, request)
 	if err != nil {
 		request.setLabels(map[string]string{
 			"response_code":     "404",
@@ -220,7 +220,7 @@ func iamSecurityCredentialsForRole(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// read the role from AWS
-	roleInfo, err := findContainerRoleByAddress(r.RemoteAddr, request)
+	roleInfo, externalId, err := findContainerRoleByAddress(r.RemoteAddr, request)
 	if err != nil {
 		request.setLabels(map[string]string{
 			"response_code":     "404",
@@ -245,7 +245,7 @@ func iamSecurityCredentialsForRole(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// assume the container role
-	assumeRole, err := assumeRoleFromAWS(*roleInfo.Arn, request)
+	assumeRole, err := assumeRoleFromAWS(*roleInfo.Arn, externalId, request)
 	if err != nil {
 		request.setLabels(map[string]string{
 			"response_code":     "404",

--- a/internal/http_helper.go
+++ b/internal/http_helper.go
@@ -17,7 +17,7 @@ func remoteIP(addr string) string {
 	return strings.Split(addr, ":")[0]
 }
 
-func findContainerRoleByAddress(addr string, request *Request) (*iam.Role, error) {
+func findContainerRoleByAddress(addr string, request *Request) (*iam.Role, string, error) {
 	var container *docker.Container
 
 	// retry finding the Docker container since sometimes Docker doesn't actually list the container until its been
@@ -48,12 +48,17 @@ func findContainerRoleByAddress(addr string, request *Request) (*iam.Role, error
 		return nil, err
 	}
 
+	externalId, err := findDockerContainerExternalId(container, request)
+	if err != nil {
+		return nil, err
+	}
+
 	role, err := readRoleFromAWS(roleName, request)
 	if err != nil {
 		return nil, err
 	}
 
-	return role, nil
+	return role, externalId, nil
 }
 
 func isCompatibleAPIVersion(r *http.Request) bool {

--- a/internal/http_helper.go
+++ b/internal/http_helper.go
@@ -48,15 +48,12 @@ func findContainerRoleByAddress(addr string, request *Request) (*iam.Role, strin
 		return nil, "", err
 	}
 
-	externalId, err := findDockerContainerExternalId(container, request)
-	if err != nil {
-		return nil, "", err
-	}
-
 	role, err := readRoleFromAWS(roleName, request)
 	if err != nil {
 		return nil, "", err
 	}
+
+	externalId := findDockerContainerExternalId(container, request)
 
 	return role, externalId, nil
 }

--- a/internal/http_helper.go
+++ b/internal/http_helper.go
@@ -40,22 +40,22 @@ func findContainerRoleByAddress(addr string, request *Request) (*iam.Role, strin
 
 	err := backoff.RetryNotify(retryable, b, notify)
 	if err != nil {
-		return nil, nil, err
+		return nil, "", err
 	}
 
 	roleName, err := findDockerContainerIAMRole(container, request)
 	if err != nil {
-		return nil, nil, err
+		return nil, "", err
 	}
 
 	externalId, err := findDockerContainerExternalId(container, request)
 	if err != nil {
-		return nil, nil, err
+		return nil, "", err
 	}
 
 	role, err := readRoleFromAWS(roleName, request)
 	if err != nil {
-		return nil, nil, err
+		return nil, "", err
 	}
 
 	return role, externalId, nil

--- a/internal/http_helper.go
+++ b/internal/http_helper.go
@@ -40,22 +40,22 @@ func findContainerRoleByAddress(addr string, request *Request) (*iam.Role, strin
 
 	err := backoff.RetryNotify(retryable, b, notify)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	roleName, err := findDockerContainerIAMRole(container, request)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	externalId, err := findDockerContainerExternalId(container, request)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	role, err := readRoleFromAWS(roleName, request)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	return role, externalId, nil


### PR DESCRIPTION
This PR adds support for sts external IDs to bring go-metadataproxy into closer parity with lyft/metadataproxy. Specifically, a container may define the environment variable `IAM_EXTERNAL_ID` which, if present, go-metadataproxy should use in the sts role assumption.

Unfortunately I hardly have a golang environment so speak of or a way to test this. I also write maybe a dozen lines of golang a year, so I'm open to review feedback if something here doesn't smell right.